### PR TITLE
Make header tags case-insensitive

### DIFF
--- a/src/cm-pgn/Header.js
+++ b/src/cm-pgn/Header.js
@@ -1,25 +1,22 @@
-/**
- * Author: shaack
- * Date: 07.03.2018
- */
+// Lower case header tags so that they are case-insensitive
 export const tags = {
-    // standard
-    Event: "Event", // the name of the tournament or match event
-    Site: "Site", // the location of the event
-    Date: "Date", // the starting date of the game (format: YYYY.MM.TT)
-    Round: "Round", // the playing round ordinal of the game
-    White: "White", // the player of the white pieces (last name, pre name)
-    Black: "Black", // the player of the black pieces (last name, pre name)
-    Result: "Result", // the result of the game (1-0, 1/2-1/2, 0-1, *)
-    // optional
-    Annotator: "Annotator", // The person providing notes to the game.
-    PlyCount: "PlyCount", // String value denoting total number of half-moves played.
-    TimeControl: "TimeControl", // 40/7200:3600 (moves per seconds: sudden death seconds)
-    Time: "Time", // Time the game started, in "HH:MM:SS" format, in local clock time.
-    Termination: "Termination", // Gives more details about the termination of the game. It may be "abandoned", "adjudication" (result determined by third-party adjudication), "death", "emergency", "normal", "rules infraction", "time forfeit", or "unterminated".
-    Mode: "Mode", // "OTB" (over-the-board) "ICS" (Internet Chess Server)
-    SetUp: "SetUp", // "0": position is start position, "1": tag FEN defines the position
-    FEN: "FEN", //  Alternative start position, tag SetUp has to be set to "1"
+    // Standard
+    Event: 'event', // Name of the tournament or match event
+    Site: 'site', // Location of the event
+    Date: 'date', // Starting date of the game (format: YYYY.MM.TT)
+    Round: 'round', // Playing round ordinal of the game
+    White: 'white', // Player of the white pieces (last name, pre name)
+    Black: 'black', // Player of the black pieces (last name, pre name)
+    Result: 'result', // Result of the game (1-0, 1/2-1/2, 0-1, *)
+    // Optional
+    Annotator: 'annotator', // The person providing notes to the game.
+    PlyCount: 'plycount', // String value denoting total number of half-moves played.
+    TimeControl: 'timecontrol', // 40/7200:3600 (moves per seconds: sudden death seconds)
+    Time: 'time', // Time the game started, in "HH:MM:SS" format, in local clock time.
+    Termination: 'termination', // Gives more details about the termination of the game. It may be "abandoned', "adjudication" (result determined by third-party adjudication), "death', "emergency', "normal', "rules infraction', "time forfeit', or "unterminated".
+    Mode: 'mode', // "OTB" (over-the-board) "ICS" (Internet Chess Server)
+    SetUp: 'setup', // "0": position is start position, "1": tag FEN defines the position
+    FEN: 'fen', //  Alternative start position, tag SetUp has to be set to "1"
 };
 
 export function parseHeader(headerString) {
@@ -29,11 +26,13 @@ export function parseHeader(headerString) {
 
     const header = new Map();
     const list = headerString.match(/\[([^\]]+)]/g);
+
     if (list !== null) {
         for (let i = 0; i < list.length; i++) {
             let ret = list[i].match(/\[(\w+)\s+"([^"]+)"/);
-            if (ret && tags[ret[1]]) {
-                header.set(ret[1], ret[2]);
+            if (ret) {
+                // Add all tags, including non-official ones (see tags above)
+                header.set(ret[1].toLowerCase(), ret[2]);
             }
         }
     }

--- a/src/cm-pgn/History.js
+++ b/src/cm-pgn/History.js
@@ -1,7 +1,3 @@
-/**
- * Author: shaack
- * Date: 07.03.2018
- */
 import {Chess} from 'chess.js';
 
 function IllegalMoveException(fen, notation) {

--- a/src/cm-pgn/Pgn.js
+++ b/src/cm-pgn/Pgn.js
@@ -1,7 +1,3 @@
-/**
- * Author: shaack
- * Date: 07.03.2018
- */
 import pgnParser from './parser/pgnParser';
 import {parseHeader, tags} from "./Header.js";
 import {parseHistory} from "./History.js";

--- a/test/Header.test.js
+++ b/test/Header.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import {Pgn} from "../src/cm-pgn/Pgn.js";
+import {tags} from "../src/cm-pgn/Header.js";
 
 describe('Pgn', () => {
   it('should parse header', () => {
@@ -13,6 +14,6 @@ describe('Pgn', () => {
         [Black "Spassky, Boris V."]
         [Result "1/2-1/2"]`);
     assert.equal(pgn.header.size, 7);
-    assert.equal(pgn.header.get("Event"), "F/S Return Match");
+    assert.equal(pgn.header.get(tags.Event), "F/S Return Match");
   })
 });


### PR DESCRIPTION
PGNs like this uses tags all in lower case:
https://github.com/DHTMLGoodies/dhtmlchess/blob/master/pgn/tactic-checkmates.pgn

This PR makes header tags case-insensitive.

It also allow including non-official tags, so that if people want to get extra metadata from PGNs, they can do so.