### PR TITLE
Bug fixes and enhancements to render() function in both History.js and Pgn.js

### DIFF
--- a/src/cm-pgn/History.js
+++ b/src/cm-pgn/History.js
@@ -20,7 +20,10 @@ export class History {
         if (!historyString) {
             this.clear()
         } else {
-            const parsedMoves = pgnParser.parse(historyString.replace(/\s\s+/g, " ").replace(/\n/g, " "))
+            const parsedMoves = pgnParser.parse(historyString
+                .replace(/\s\s+/g, " ")
+                .replace(/\n/g, " ")
+            );
             this.moves = this.traverse(parsedMoves[0], setUpFen, undefined, 1, sloppy)
         }
         this.setUpFen = setUpFen
@@ -71,7 +74,7 @@ export class History {
                     moves.push(move)
                     previousMove = move
                 } else {
-                    throw new IllegalMoveException(chess.fen(), notation)
+                    throw new IllegalMoveException(chess.fen(), notation);
                 }
             }
             ply++
@@ -178,36 +181,42 @@ export class History {
         return move
     }
 
-    render() {
-        const renderVariation = (variation) => {
+    render(renderComments=true, renderNags=true) {
+        const renderVariation = (variation, needReminder=false) => {
             let result = ""
-            let i = 0
             for (let move of variation) {
-                if(i % 2 === 0) {
-                    result += (i / 2 + 1) + ". "
+                if(move.ply % 2 === 1) {
+                    result += Math.floor(move.ply / 2) + 1 + ". "
                 }
-                if (move.nag) {
-                    result += "$" + move.nag + " "
+                else if (result.length === 0 || needReminder) {
+                    result += move.ply / 2 + "... ";
                 }
-                if (move.commentBefore) {
-                    result += "{" + move.commentBefore + "} "
+                needReminder = false;
+                if (renderNags && move.nag) {
+                    result += "$" + move.nag + " ";
+                }
+                if (renderComments && move.commentBefore) {
+                    result += "{" + move.commentBefore + "} ";
+                    needReminder = true;
                 }
                 result += move.san + " "
-                if (move.commentMove) {
-                    result += "{" + move.commentMove + "} "
+                if (renderComments && move.commentMove) {
+                    result += "{" + move.commentMove + "} ";
+                    needReminder = true;
                 }
-                if (move.commentAfter) {
-                    result += "{" + move.commentAfter + "} "
+                if (renderComments && move.commentAfter) {
+                    result += "{" + move.commentAfter + "} ";
+                    needReminder = true;
                 }
                 if (move.variations.length > 0) {
                     for (let variation of move.variations) {
-                        result += "(" + renderVariation(variation) + ")"
+                        result += "(" + renderVariation(variation) + ") ";
+                        needReminder = true;
                     }
                 }
-                result += " "
-                i++
+                result += " ";
             }
-            return result
+            return result;
         }
         let ret = renderVariation(this.moves)
         // remove spaces before brackets

--- a/src/cm-pgn/Pgn.js
+++ b/src/cm-pgn/Pgn.js
@@ -10,9 +10,9 @@ export class Pgn {
 
     constructor(pgnString = "", props = {}) {
         // only the header?
-        const lastHeaderElement =  pgnString.trim().substr(-1) === "]" ? pgnString.length : pgnString.lastIndexOf("]\n\n") + 1
-        const headerString = pgnString.substr(0, lastHeaderElement)
-        const historyString = pgnString.substr(lastHeaderElement)
+        const lastHeaderElement =  pgnString.trim().substring(-1) === "]" ? pgnString.length : pgnString.lastIndexOf("]\n\n") + 1
+        const headerString = pgnString.substring(0, lastHeaderElement)
+        const historyString = pgnString.substring(lastHeaderElement)
         const sloppy = !!props.sloppy
         this.header = new Header(headerString)
         if (this.header.tags[TAGS.SetUp] === "1" && this.header.tags[TAGS.FEN]) {
@@ -39,13 +39,13 @@ export class Pgn {
         return lines.join("\n")
     }
 
-    render() {
-        const header = this.header.render()
-        let history = this.history.render()
+    render(renderHeader = true, renderComments = true, renderNags = true) {
+        const header = renderHeader ? (this.header.render() + "\n") : "";
+        let history = this.history.render(renderComments, renderNags);
         if(this.header.tags[TAGS.Result]) {
-            history += " " + this.header.tags[TAGS.Result]
+            history += " " + this.header.tags[TAGS.Result];
         }
-        return header + "\n" + this.wrap(history, 80)
+        return header + this.wrap(history, 80)
     }
 
 }


### PR DESCRIPTION
The render() function now outputs PGNs with variations in the same format Lichess uses. Prior to this branch, there were a few bugs that caused the render() function in History.js to output strings that, although mostly followed the PGN standard, could be slightly unreadable. For example, for the PGN "1. e4 (1. d4) 1... e5" the previous render() function would output "1. e4 (1. d4) e5." Includes a few other bug fixes as well.

In addition, the render() function in History.js now accepts two optional boolean arguments: renderComments and renderNags. The values of these arguments dictate whether comments are rendered and nags are rendered, respectively. The render() function in Pgn.js now accepts the same two optional boolean arguments in addition to a third: renderHeader. The value of this argument dictates whether a header is rendered in the PGN.

I have performed basic unit tests to verify that History.js and Pgn.js work as intended, to the best of my knowledge. However, running more rigorous tests wouldn't hurt.