### PR TITLE
Fix inconsistent next and previous pointers

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -43,8 +43,12 @@ export class History {
                 const move = chess.move(notation, {sloppy: sloppy})
                 if (move) {
                     if (previousMove) {
-                        move.previous = previousMove
-                        previousMove.next = move
+                        if (!move.previous) {
+                            move.previous = previousMove
+                        }
+                        if (!previousMove.next) {
+                            previousMove.next = move
+                        }
                     } else {
                         move.previous = null
                     }


### PR DESCRIPTION
See https://github.com/shaack/cm-pgn/issues/20.

# Overview

* Changes `History.traverse()` to only set `previous` and `next` pointers if move doesn't already have pointers set.
* Adds two unit tests that recursively checks ALL variation lines in a PGN and ensures self-consistency

This fixes (what I believe to be) a bug in traverse where a move in the main line will get its `next` property set to the first move of an alternate line rather than the next move in its own line.

In general, it seems the correct behavior ought to be that every move in `move.variation` should satisfy 

```
move.variation[0] <--> move.variation[1] <--> move.variation[2] <--> ... <--> move.variation[n]
```

If one of those moves has **variations** branching off it, that shouldn't matter to that move's `previous` and `next` pointers. 