### PR TITLE
change main to point to pgn.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cm-pgn",
   "version": "3.3.2",
   "description": "Module for parsing and rendering of PGNs (Portable Game Notation)",
-  "main": "src/cm-pgn/Pgn.js",
+  "main": "src/Pgn.js",
   "type": "module",
   "scripts": {
     "test": "echo 'request test/index.html for testing'"


### PR DESCRIPTION
change main key in package.json
to point to pgn.js file

this allows projects to import using ESM directly, for example typescript projects that are set to ESM imports rather than CJS imports

the main section of the package.json is the entry pointif you don't have an index.js
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#main